### PR TITLE
Enhancements from Nick W

### DIFF
--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -217,13 +217,13 @@ if "model_start" in list(input_dict.keys()):
     model_start = np.r_[input_dict["model_start"]]
     assert model_start.shape[0] == 1 or model_start.shape[0] == 3, "Start model needs to be a scalar or 3 component vector"
 else:
-    model_start = 0
+    model_start = [0.0]
 
 if "model_reference" in list(input_dict.keys()):
     model_reference = np.r_[input_dict["model_reference"]]
     assert model_reference.shape[0] == 1 or model_reference.shape[0] == 3, "Start model needs to be a scalar or 3 component vector"
 else:
-    model_reference = 0
+    model_reference = [0.0]
 
 if len(octree_levels_padding) < len(octree_levels_obs):
     octree_levels_padding += octree_levels_obs[len(octree_levels_padding):]

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -686,6 +686,9 @@ if show_graphics:
     axs.set_ylabel('$\phi_d$', size=16, rotation=0)
     axs.set_xlabel('Iterations', size=14)
     twin.set_ylabel('$\phi_m$', size=16, rotation=0)
+    t = fig.get_size_inches()
+    fig.set_size_inches(t[0]*2, t[1]*2)
+    fig.savefig(outDir + 'Convergence_curve.png', bbox_inches='tight', dpi=600)
     plt.show(block=False)
 
 # Repeat inversion in spherical
@@ -826,6 +829,9 @@ if input_dict["inversion_type"].lower() == 'mvis':
         axs.set_ylabel('$\phi_d$', size=16, rotation=0)
         axs.set_xlabel('Iterations', size=14)
         twin.set_ylabel('$\phi_m$', size=16, rotation=0)
+        t = fig.get_size_inches()
+        fig.set_size_inches(t[0]*2, t[1]*2)
+        fig.savefig(outDir + 'Convergence_curve_spherical.png', bbox_inches='tight', dpi=600)
         plt.show(block=False)
     
 # Ouput result

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -112,13 +112,13 @@ else:
 # Update the specified data uncertainty
 if "new_uncert" in list(input_dict.keys()) and input_dict["data_type"].lower() in ['ubc_mag', 'ubc_grav']:
     new_uncert = input_dict["new_uncert"]
+    if new_uncert != False:
+        assert (len(new_uncert) == 2 and all(np.asarray(new_uncert) >= 0)), "New uncertainty requires pct fraction (0-1) and floor."
+        survey.std = np.maximum(abs(new_uncert[0]*survey.dobs),new_uncert[1])
 else:
-    new_uncert = [-1, -1]
-
-if len(new_uncert) == 2 and all(np.asarray(new_uncert) >= 0):
-    survey.std = np.maximum(abs(new_uncert[0]*survey.dobs),new_uncert[1])
+    new_uncert = False
     
-elif survey.std is None:
+if survey.std is None:
     survey.std = survey.dobs * 0 + 10 # Default
 
 print('Min uncert: {0:.6g} nT'.format(survey.std.min()))

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -112,7 +112,7 @@ else:
 # Update the specified data uncertainty
 if "new_uncert" in list(input_dict.keys()) and input_dict["data_type"].lower() in ['ubc_mag', 'ubc_grav']:
     new_uncert = input_dict["new_uncert"]
-    if new_uncert != False:
+    if new_uncert:
         assert (len(new_uncert) == 2 and all(np.asarray(new_uncert) >= 0)), "New uncertainty requires pct fraction (0-1) and floor."
         survey.std = np.maximum(abs(new_uncert[0]*survey.dobs),new_uncert[1])
 else:

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -22,7 +22,7 @@ from scipy.interpolate import NearestNDInterpolator
 from scipy.spatial import cKDTree
 from SimPEG.Utils import mkvc
 import dask
-from dask.distributed import Client
+# from dask.distributed import Client
 import multiprocessing
 import sys
 
@@ -201,6 +201,11 @@ else:
 
 if "tileProblem" in list(input_dict.keys()):
     tileProblem = input_dict["tileProblem"]
+
+if parallelized == 'dask':
+    dask.config.set({'array.chunk-size': '256MiB'})
+    dask.config.set(scheduler='threads')
+    dask.config.set(num_workers=n_cpu)
 
 rxLoc = survey.rxLoc
 

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -119,7 +119,7 @@ else:
     new_uncert = False
     
 if survey.std is None:
-    survey.std = survey.dobs * 0 + 10 # Default
+    survey.std = survey.dobs * 0 + 1 # Default
 
 print('Min uncert: {0:.6g} nT'.format(survey.std.min()))
 
@@ -219,11 +219,11 @@ if "model_start" in list(input_dict.keys()):
 else:
     model_start = 0
 
-if "model_ref" in list(input_dict.keys()):
-    model_ref = np.r_[input_dict["model_ref"]]
-    assert model_ref.shape[0] == 1 or model_ref.shape[0] == 3, "Start model needs to be a scalar or 3 component vector"
+if "model_reference" in list(input_dict.keys()):
+    model_reference = np.r_[input_dict["model_reference"]]
+    assert model_reference.shape[0] == 1 or model_reference.shape[0] == 3, "Start model needs to be a scalar or 3 component vector"
 else:
-    model_start = 0
+    model_reference = 0
 
 if len(octree_levels_padding) < len(octree_levels_obs):
     octree_levels_padding += octree_levels_obs[len(octree_levels_padding):]
@@ -585,15 +585,15 @@ if input_dict["inversion_type"].lower() in ['grav', 'mag']:
         alpha_z=alphas[3]
         )
     reg.norms = np.c_[model_norms].T
-    reg.mref = np.zeros(nC) * model_ref[0]
+    reg.mref = np.zeros(nC) * model_reference[0]
     reg.cell_weights = wrGlobal
     mstart = np.zeros(nC) * model_start[0]
 else:
-    if len(model_ref) == 3:
-        mref = np.kron(model_ref, np.ones(nC))
+    if len(model_reference) == 3:
+        mref = np.kron(model_reference, np.ones(nC))
     else:
         # Assumes amplitude reference, distributed on 3 components in inducing field direction
-        mref = np.kron(model_ref * Utils.matutils.dipazm_2_xyz(dip=survey.srcField.param[1], azm_N=survey.srcField.param[2])[0,:], np.ones(nC))
+        mref = np.kron(model_reference * Utils.matutils.dipazm_2_xyz(dip=survey.srcField.param[1], azm_N=survey.srcField.param[2])[0,:], np.ones(nC))
 
     if len(model_start) == 3:
         mstart = np.kron(model_start, np.ones(nC))

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -220,7 +220,7 @@ if len(octree_levels_padding) < len(octree_levels_obs):
 if "core_cell_size" in list(input_dict.keys()):
     core_cell_size = input_dict["core_cell_size"]
 else:
-    asser("'core_cell_size' must be added to the inputs")
+    assert("'core_cell_size' must be added to the inputs")
 
 if "depth_core" in list(input_dict.keys()):
     depth_core = input_dict["depth_core"]

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -115,7 +115,7 @@ if "new_uncert" in list(input_dict.keys()) and input_dict["data_type"].lower() i
 else:
     new_uncert = [-1, -1]
 
-if len(new_uncert) == 2 and all(np.asarray(new_uncert) > 0):
+if len(new_uncert) == 2 and all(np.asarray(new_uncert) >= 0):
     survey.std = np.maximum(abs(new_uncert[0]*survey.dobs),new_uncert[1])
     
 elif survey.std is None:

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -112,17 +112,13 @@ else:
 # Update the specified data uncertainty
 if "new_uncert" in list(input_dict.keys()) and input_dict["data_type"].lower() in ['ubc_mag', 'ubc_grav']:
     new_uncert = input_dict["new_uncert"]
-    if new_uncert != False:
-        if len(new_uncert) == 2:
-            assert all(np.asarray(new_uncert) >= 0), "New uncertainty fraction and floor must be >= 0"
-        else:
-            new_uncert = new_uncert[:1]
-            
-        survey.std = np.maximum(abs(new_uncert[0]*survey.dobs),new_uncert[1])
 else:
-    new_uncert = False
+    new_uncert = [-1, -1]
+
+if len(new_uncert) == 2 and all(np.asarray(new_uncert) >= 0):
+    survey.std = np.maximum(abs(new_uncert[0]*survey.dobs),new_uncert[1])
     
-if survey.std is None:
+elif survey.std is None:
     survey.std = survey.dobs * 0 + 10 # Default
 
 print('Min uncert: {0:.6g} nT'.format(survey.std.min()))

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -112,13 +112,17 @@ else:
 # Update the specified data uncertainty
 if "new_uncert" in list(input_dict.keys()) and input_dict["data_type"].lower() in ['ubc_mag', 'ubc_grav']:
     new_uncert = input_dict["new_uncert"]
+    if new_uncert != False:
+        if len(new_uncert) == 2:
+            assert all(np.asarray(new_uncert) >= 0), "New uncertainty fraction and floor must be >= 0"
+        else:
+            new_uncert = new_uncert[:1]
+            
+        survey.std = np.maximum(abs(new_uncert[0]*survey.dobs),new_uncert[1])
 else:
-    new_uncert = [-1, -1]
-
-if len(new_uncert) == 2 and all(np.asarray(new_uncert) >= 0):
-    survey.std = np.maximum(abs(new_uncert[0]*survey.dobs),new_uncert[1])
+    new_uncert = False
     
-elif survey.std is None:
+if survey.std is None:
     survey.std = survey.dobs * 0 + 10 # Default
 
 print('Min uncert: {0:.6g} nT'.format(survey.std.min()))

--- a/PF_inversion_20190907.py
+++ b/PF_inversion_20190907.py
@@ -14,6 +14,7 @@ from SimPEG import (
     )
 import SimPEG.PF as PF
 import numpy as np
+import matplotlib.pyplot as plt
 import os
 import json
 from discretize.utils import meshutils
@@ -238,6 +239,11 @@ else:
 if "tileProblem" in list(input_dict.keys()):
     tileProblem = input_dict["tileProblem"]
 
+if "show_graphics" in list(input_dict.keys()):
+    show_graphics = input_dict["show_graphics"]
+else:
+    show_graphics = False
+
 if parallelized == 'dask':
     dask.config.set({'array.chunk-size': '256MiB'})
     dask.config.set(scheduler='threads')
@@ -407,6 +413,18 @@ if meshInput is None:
 else:
     mesh = meshInput
 
+if show_graphics:
+    # Plot a slice
+    slicePosition = rxLoc[:, 1].mean()
+    
+    sliceInd = int(round(np.searchsorted(mesh.vectorCCy, slicePosition)))
+    fig, ax1 = plt.figure(), plt.subplot()
+    im = mesh.plotSlice(np.log10(mesh.vol), normal='Y', ax=ax1, ind=sliceInd, grid=True, pcolorOpts={"cmap":"plasma"})
+    ax1.set_aspect('equal')
+    t = fig.get_size_inches()
+    fig.set_size_inches(t[0]*2, t[1]*2)
+    fig.savefig(outDir + 'Section_%.0f.png' % slicePosition, bbox_inches='tight', dpi=600)
+    plt.show(block=False)
 
 print("Calculating active cells from topo")
 # Compute active cells


### PR DESCRIPTION
- Level input data by removing mean data value (`"subtract_mean": true,`)
- Apply new uncertainties: (`"new_uncert": [0,5],` where first entry is % (0-1) and second is minimum floor)
- add dask parameters
- Allow stop after MVI-C (`"inversion_type":"MVI",` versus `"inversion_type":"MVIS",`)
- Enable start and reference models as either vector or inputs (`"model_start": [0,0,0],` or `"model_ref": 1e-4,`). If scalar then it assumes it is an amplitude in the direction of the inducing field.
- Add input switch for plotting graphics (`"show_graphics": true`)
- Plot a slice through the global mesh